### PR TITLE
Make DbContext short-living

### DIFF
--- a/API/Services/IPlayerInfoRepository.cs
+++ b/API/Services/IPlayerInfoRepository.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using OpenMod.API.Ioc;
 using OpenMod.API.Users;
@@ -7,7 +8,7 @@ using Pustalorc.PlayerInfoLib.Unturned.API.Classes;
 namespace Pustalorc.PlayerInfoLib.Unturned.API.Services
 {
     [Service]
-    public interface IPlayerInfoRepository
+    public interface IPlayerInfoRepository : IAsyncDisposable
     {
         /// <summary>
         /// Gets the current server from the Servers DbSet.

--- a/ContainerConfigurator.cs
+++ b/ContainerConfigurator.cs
@@ -1,6 +1,7 @@
 using OpenMod.API.Plugins;
 using Pustalorc.PlayerInfoLib.Unturned.Database;
 using OpenMod.EntityFrameworkCore.MySql.Extensions;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Pustalorc.PlayerInfoLib.Unturned
 {
@@ -8,7 +9,7 @@ namespace Pustalorc.PlayerInfoLib.Unturned
     {
         public void ConfigureContainer(IPluginServiceConfigurationContext context)
         {
-            context.ContainerBuilder.AddMySqlDbContext<PlayerInfoLibDbContext>();
+            context.ContainerBuilder.AddMySqlDbContext<PlayerInfoLibDbContext>(ServiceLifetime.Transient);
         }
     }
 }

--- a/Database/PlayerInfoRepositoryServiceImplementation.cs
+++ b/Database/PlayerInfoRepositoryServiceImplementation.cs
@@ -18,7 +18,7 @@ using SDG.Unturned;
 namespace Pustalorc.PlayerInfoLib.Unturned.Database
 {
     [PluginServiceImplementation(Lifetime = ServiceLifetime.Transient, Priority = Priority.Lowest)]
-    public class PlayerInfoRepositoryServiceImplementation : IPlayerInfoRepository, IAsyncDisposable
+    public class PlayerInfoRepositoryServiceImplementation : IPlayerInfoRepository
     {
         private readonly PlayerInfoLibDbContext m_DbContext;
 

--- a/Database/PlayerInfoRepositoryServiceImplementation.cs
+++ b/Database/PlayerInfoRepositoryServiceImplementation.cs
@@ -17,8 +17,8 @@ using SDG.Unturned;
 
 namespace Pustalorc.PlayerInfoLib.Unturned.Database
 {
-    [PluginServiceImplementation(Lifetime = ServiceLifetime.Singleton, Priority = Priority.Lowest)]
-    public class PlayerInfoRepositoryServiceImplementation : IPlayerInfoRepository
+    [PluginServiceImplementation(Lifetime = ServiceLifetime.Transient, Priority = Priority.Lowest)]
+    public class PlayerInfoRepositoryServiceImplementation : IPlayerInfoRepository, IAsyncDisposable
     {
         private readonly PlayerInfoLibDbContext m_DbContext;
 
@@ -197,6 +197,11 @@ namespace Pustalorc.PlayerInfoLib.Unturned.Database
         public int SaveChanges()
         {
             return m_DbContext.SaveChanges();
+        }
+
+        public ValueTask DisposeAsync()
+        {
+            return m_DbContext.DisposeAsync();
         }
     }
 }

--- a/PlayerInfoLibrary.cs
+++ b/PlayerInfoLibrary.cs
@@ -1,6 +1,7 @@
 using System;
 using Cysharp.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using OpenMod.API.Plugins;
 using OpenMod.Unturned.Plugins;
@@ -17,30 +18,24 @@ namespace Pustalorc.PlayerInfoLib.Unturned
     public class PlayerInfoLibrary : OpenModUnturnedPlugin
     {
         private readonly ILogger<PlayerInfoLibrary> m_Logger;
+        private readonly IServiceProvider m_ServiceProvider;
 
-        private readonly PlayerInfoLibDbContext m_DbContext;
-
-        private readonly IPlayerInfoRepository m_PlayerInfoRepository;
-
-        public PlayerInfoLibrary(ILogger<PlayerInfoLibrary> logger, IServiceProvider serviceProvider,
-            PlayerInfoLibDbContext dbContext, IPlayerInfoRepository playerInfoRepository) : base(serviceProvider)
+        public PlayerInfoLibrary(ILogger<PlayerInfoLibrary> logger, IServiceProvider serviceProvider) : base(serviceProvider)
         {
             m_Logger = logger;
-
-            m_DbContext = dbContext;
-
-            m_PlayerInfoRepository = playerInfoRepository;
+            m_ServiceProvider = serviceProvider;
         }
 
         protected override async UniTask OnLoadAsync()
         {
-            await m_DbContext.Database.MigrateAsync();
+            await using var dbContext = m_ServiceProvider.GetRequiredService<PlayerInfoLibDbContext>();
+            await dbContext.Database.MigrateAsync();
 
-            await m_PlayerInfoRepository.CheckAndRegisterCurrentServerAsync();
+            await using var playerInfoRepository = m_ServiceProvider.GetRequiredService<IPlayerInfoRepository>();
+            await playerInfoRepository.CheckAndRegisterCurrentServerAsync();
 
             m_Logger.LogInformation("Player Info Library for Unturned by Pustalorc was loaded correctly.");
         }
-
 
         protected override UniTask OnUnloadAsync()
         {


### PR DESCRIPTION
Fixes:
1. If a player played on one server, then another, the second server will use cached data resulting in overriding the first server's data. ([link 1](https://discord.com/channels/666327627124047872/781264475159658497/909749305521360917) and [link 2](https://discord.com/channels/666327627124047872/730705179204255800/908496560952860702))

2. [Multithreading issue](https://discord.com/channels/666327627124047872/730705179204255800/905938605950775306).

Finishes https://github.com/Pustalorc/PlayerInfoLib/pull/4.
